### PR TITLE
style non-clickable sidebar headings

### DIFF
--- a/src/css/custom.css
+++ b/src/css/custom.css
@@ -98,3 +98,11 @@ html[data-theme=dark] .header-discord-link:before {
   content: '\2600';
   color: #ffd557;
 }
+
+a.menu__link:not([href]) {
+  color: black;
+}
+
+html[data-theme=dark] a.menu__link:not([href]) {
+  color: white;
+}


### PR DESCRIPTION
It wasn't obvious that the sidebar category headings were non-clickable.

n/t